### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can set environment variable `NODE_ENV` to `production` for testing in dev m
 
 ## Setup
 
-- Add `nuxt-cloudflare-analytics` dependency using yarn or npm to your project `npx nuxi@latest module add cloudflare-analytics
+- Add `nuxt-cloudflare-analytics` dependency to your project with `npx nuxi@latest module add cloudflare-analytics`
 - Add `nuxt-cloudflare-analytics` to `modules` section of `nuxt.config.ts`
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can set environment variable `NODE_ENV` to `production` for testing in dev m
 
 ## Setup
 
-- Add `nuxt-cloudflare-analytics` dependency using yarn or npm to your project `npm i nuxt-cloudflare-analytics` or `yarn install nuxt-cloudflare-analytics`
+- Add `nuxt-cloudflare-analytics` dependency using yarn or npm to your project `npx nuxi@latest module add cloudflare-analytics
 - Add `nuxt-cloudflare-analytics` to `modules` section of `nuxt.config.ts`
 
 ```ts


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
